### PR TITLE
Cache bot metadata and storage client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,6 +2762,7 @@ dependencies = [
  "dotenvy",
  "lambda_runtime",
  "log",
+ "once_cell",
  "pretty_env_logger",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ aws-config = "1.0"
 aws-sdk-dynamodb = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
+once_cell = "1.19"
 
 [features]
 default = ["axum-server"]

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -68,8 +68,6 @@ pub fn get_available_models() -> Vec<String> {
         "gpt-4".to_string(),
         "gpt-4-turbo".to_string(),
         "gpt-3.5-turbo".to_string(),
-        "o1-preview".to_string(),
-        "o1-mini".to_string(),
     ]
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2,6 +2,9 @@ use log::info;
 
 #[cfg(feature = "lambda")]
 use log::warn;
+use once_cell::sync::OnceCell;
+use teloxide::RequestError;
+use teloxide::requests::Requester;
 use teloxide::{prelude::*, utils::command::BotCommands};
 
 #[cfg(feature = "lambda")]
@@ -11,11 +14,31 @@ use serde_json::Value;
 
 use crate::commands::{Command, answer};
 
+static BOT_USERNAME: OnceCell<String> = OnceCell::new();
+
+async fn resolve_bot_username(bot: &Bot) -> Result<&str, RequestError> {
+    if let Some(username) = BOT_USERNAME.get() {
+        return Ok(username.as_str());
+    }
+
+    let bot_user = bot.get_me().await?;
+    let username = bot_user
+        .username
+        .clone()
+        .unwrap_or_else(|| "bot".to_string());
+
+    let _ = BOT_USERNAME.set(username);
+
+    Ok(BOT_USERNAME
+        .get()
+        .expect("bot username should be set")
+        .as_str())
+}
+
 pub async fn handle_message(bot: Bot, msg: Message) -> ResponseResult<()> {
     if let Some(text) = msg.text() {
         // Get bot info to use the correct username for command parsing
-        let bot_user = bot.get_me().await?;
-        let bot_username = bot_user.username.as_deref().unwrap_or("bot");
+        let bot_username = resolve_bot_username(&bot).await?;
 
         info!("📝 Processing message: '{text}' with bot username: @{bot_username}");
 
@@ -56,7 +79,9 @@ pub async fn handle_message(bot: Bot, msg: Message) -> ResponseResult<()> {
                 bot.send_message(msg.chat.id, response).await?;
             } else if !processed_text.trim().is_empty() {
                 // Not a command, treat as general AI chat (default behavior)
-                info!("🤖 No command detected - defaulting to /general for message: '{processed_text}'");
+                info!(
+                    "🤖 No command detected - defaulting to /general for message: '{processed_text}'"
+                );
                 info!("🔄 Converting to Command::General");
                 answer(bot, msg, Command::General(processed_text)).await?;
             } else {
@@ -87,20 +112,18 @@ pub async fn handle_message(bot: Bot, msg: Message) -> ResponseResult<()> {
 }
 
 #[cfg(feature = "lambda")]
-pub async fn lambda_handler(
-    event: LambdaEvent<Value>,
-) -> Result<Value, LambdaError> {
+pub async fn lambda_handler(event: LambdaEvent<Value>) -> Result<Value, LambdaError> {
     info!("🔗 Lambda received event: {:?}", event.payload);
-    
+
     let bot = Bot::from_env();
-    
+
     // Parse the Telegram webhook update from the Lambda event body
     if let Some(body) = event.payload.get("body").and_then(|b| b.as_str()) {
         info!("📦 Extracted body from Lambda event: {body}");
-        
+
         if let Ok(update) = serde_json::from_str::<teloxide::types::Update>(body) {
             info!("✅ Successfully parsed Telegram update: {:?}", update.id);
-            
+
             if let teloxide::types::UpdateKind::Message(message) = update.kind {
                 let _ = handle_message(bot, message).await;
             } else {
@@ -112,7 +135,7 @@ pub async fn lambda_handler(
     } else {
         warn!("❌ No body field found in Lambda event");
     }
-    
+
     // Return success response
     Ok(serde_json::json!({
         "statusCode": 200,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,7 @@
 use aws_config::BehaviorVersion;
 use aws_sdk_dynamodb::{Client as DynamoDbClient, Error as DynamoDbError};
 use log::{info, warn};
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
@@ -19,7 +20,7 @@ impl UserPreferences {
     pub fn new(chat_id: String, ai_model: String) -> Self {
         let now = chrono::Utc::now();
         let expires_at = now.timestamp() + (365 * 24 * 60 * 60); // 1 year from now
-        
+
         Self {
             chat_id,
             ai_model,
@@ -59,31 +60,34 @@ pub struct DynamoDbStorage {
 
 impl DynamoDbStorage {
     pub async fn new() -> Result<Self, StorageError> {
-        let table_name = std::env::var("DYNAMODB_TABLE_NAME")
-            .map_err(|_| StorageError::Configuration("DYNAMODB_TABLE_NAME environment variable not set".to_string()))?;
+        let table_name = std::env::var("DYNAMODB_TABLE_NAME").map_err(|_| {
+            StorageError::Configuration(
+                "DYNAMODB_TABLE_NAME environment variable not set".to_string(),
+            )
+        })?;
 
         let config = aws_config::defaults(BehaviorVersion::v2025_01_17())
             .load()
             .await;
-        
+
         let client = DynamoDbClient::new(&config);
-        
+
         info!("🗃️ DynamoDB client initialized for table: {table_name}");
-        
-        Ok(Self {
-            client,
-            table_name,
-        })
+
+        Ok(Self { client, table_name })
     }
 
     pub async fn get_user_model(&self, chat_id: &str) -> Result<Option<String>, StorageError> {
         info!("📖 Getting model preference for chat_id: {chat_id}");
-        
+
         let result = self
             .client
             .get_item()
             .table_name(&self.table_name)
-            .key("chat_id", aws_sdk_dynamodb::types::AttributeValue::S(chat_id.to_string()))
+            .key(
+                "chat_id",
+                aws_sdk_dynamodb::types::AttributeValue::S(chat_id.to_string()),
+            )
             .send()
             .await
             .map_err(|e| StorageError::DynamoDb(DynamoDbError::from(e)))?;
@@ -108,16 +112,28 @@ impl DynamoDbStorage {
 
     pub async fn set_user_model(&self, chat_id: &str, model: &str) -> Result<(), StorageError> {
         info!("💾 Setting model preference for chat_id {chat_id} to: {model}");
-        
+
         let preferences = UserPreferences::new(chat_id.to_string(), model.to_string());
-        
+
         let mut item = HashMap::new();
-        item.insert("chat_id".to_string(), aws_sdk_dynamodb::types::AttributeValue::S(preferences.chat_id));
-        item.insert("ai_model".to_string(), aws_sdk_dynamodb::types::AttributeValue::S(preferences.ai_model));
-        item.insert("updated_at".to_string(), aws_sdk_dynamodb::types::AttributeValue::S(preferences.updated_at));
-        
+        item.insert(
+            "chat_id".to_string(),
+            aws_sdk_dynamodb::types::AttributeValue::S(preferences.chat_id),
+        );
+        item.insert(
+            "ai_model".to_string(),
+            aws_sdk_dynamodb::types::AttributeValue::S(preferences.ai_model),
+        );
+        item.insert(
+            "updated_at".to_string(),
+            aws_sdk_dynamodb::types::AttributeValue::S(preferences.updated_at),
+        );
+
         if let Some(expires_at) = preferences.expires_at {
-            item.insert("expires_at".to_string(), aws_sdk_dynamodb::types::AttributeValue::N(expires_at.to_string()));
+            item.insert(
+                "expires_at".to_string(),
+                aws_sdk_dynamodb::types::AttributeValue::N(expires_at.to_string()),
+            );
         }
 
         self.client
@@ -135,7 +151,7 @@ impl DynamoDbStorage {
     #[allow(dead_code)]
     pub async fn list_all_preferences(&self) -> Result<Vec<UserPreferences>, StorageError> {
         info!("📋 Listing all user preferences");
-        
+
         let result = self
             .client
             .scan()
@@ -145,7 +161,7 @@ impl DynamoDbStorage {
             .map_err(|e| StorageError::DynamoDb(DynamoDbError::from(e)))?;
 
         let mut preferences = Vec::new();
-        
+
         if let Some(items) = result.items {
             for item in items {
                 if let (Some(chat_id), Some(model), Some(updated_at)) = (
@@ -153,10 +169,11 @@ impl DynamoDbStorage {
                     item.get("ai_model").and_then(|v| v.as_s().ok()),
                     item.get("updated_at").and_then(|v| v.as_s().ok()),
                 ) {
-                    let expires_at = item.get("expires_at")
+                    let expires_at = item
+                        .get("expires_at")
                         .and_then(|v| v.as_n().ok())
                         .and_then(|s| s.parse::<i64>().ok());
-                    
+
                     preferences.push(UserPreferences {
                         chat_id: chat_id.clone(),
                         ai_model: model.clone(),
@@ -173,8 +190,19 @@ impl DynamoDbStorage {
 }
 
 // Factory function to create storage client
-pub async fn create_storage() -> Result<DynamoDbStorage, StorageError> {
-    DynamoDbStorage::new().await
+static STORAGE: OnceCell<DynamoDbStorage> = OnceCell::new();
+
+pub async fn create_storage() -> Result<&'static DynamoDbStorage, StorageError> {
+    if let Some(storage) = STORAGE.get() {
+        return Ok(storage);
+    }
+
+    let storage = DynamoDbStorage::new().await?;
+    let _ = STORAGE.set(storage);
+
+    STORAGE.get().ok_or_else(|| {
+        StorageError::Configuration("DynamoDB storage failed to initialize".to_string())
+    })
 }
 
 // Helper function to get default model


### PR DESCRIPTION
## Summary
- cache the bot username once and reuse it when handling messages instead of calling `get_me` for every update
- reuse a single DynamoDB storage client via a global `OnceCell` to avoid repeated AWS SDK initialization
- drop unsupported `o1-preview` and `o1-mini` entries from the `/model` list and add the `once_cell` dependency

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d35deff2588332b14a20d77d31f05e